### PR TITLE
Fix infinite loop: don't cache intercept HTML

### DIFF
--- a/event/intercept.php
+++ b/event/intercept.php
@@ -277,9 +277,7 @@ class intercept implements EventSubscriberInterface
 
 		// Prevent an infinite loop: don't cache the "Loading..." redirect to Anubis.
 		// Otherwise the user will keep being sent back to Anubis, even after they have a valid cookie.
-		header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
-		header('Pragma: no-cache');
-		header('Expires: 0');
+		header('Cache-Control: no-store');
 
 		echo <<< END
 <html lang="en">

--- a/event/intercept.php
+++ b/event/intercept.php
@@ -157,7 +157,7 @@ class intercept implements EventSubscriberInterface
 			$this->anubis->logout_cookie();
 
 			$data = ['anubisbb_pass' => 1];
-			$sql  = 'UPDATE ' . SESSIONS_TABLE . ' 
+			$sql  = 'UPDATE ' . SESSIONS_TABLE . '
 				SET ' . $this->db->sql_build_array('UPDATE', $data) . '
 				WHERE session_id = "' . $this->user->data['session_id'] . '"';
 			$this->db->sql_query($sql);
@@ -274,6 +274,12 @@ class intercept implements EventSubscriberInterface
 	private function intercept()
 	{
 		$route = $this->controller_helper->route('neodev_anubisbb_make_challenge');
+
+		// Prevent an infinite loop: don't cache the "Loading..." redirect to Anubis.
+		// Otherwise the user will keep being sent back to Anubis, even after they have a valid cookie.
+		header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+		header('Pragma: no-cache');
+		header('Expires: 0');
 
 		echo <<< END
 <html lang="en">


### PR DESCRIPTION
If a user visits a protected page without an Anubis cookie, we inject intercept HTML to send them to Anubis first; once they get their cookie, Anubis redirects them back to that same protected page.

Previously, we allowed the browser to cache the intercept on that page. This meant that when Anubis redirected the user back to the protected page, their browser might load the intercept from cache and send them back to Anubis in an infinite loop, even though they have a valid cookie now. This commit breaks the loop by sending anti-cache headers right before the intercept HTML.